### PR TITLE
feat(world): add edge case room placement logic to avoid `int32` overflow

### DIFF
--- a/include/game/world/generator.h
+++ b/include/game/world/generator.h
@@ -9,6 +9,8 @@
 #ifndef GAME_WORLD_GENERATOR_H
 #define GAME_WORLD_GENERATOR_H
 
+#include <stdint.h>
+
 /**
  * @brief Initializes the generator and the world's starting state.
  *
@@ -36,6 +38,6 @@ int generator_init(unsigned int seed);
  * @param center_x The center grid x-coordinate of the chunk to generate.
  * @param center_y The center grid y-coordinate of the chunk to generate.
  */
-int generator_create_chunk(int center_x, int center_y);
+int generator_create_chunk(int32_t center_x, int32_t center_y);
 
 #endif

--- a/include/game/world/grid.h
+++ b/include/game/world/grid.h
@@ -24,8 +24,8 @@ struct world_cell {
                                       */
     Model model;                     /**< The loaded Raylib 3D model. */
     bool is_model_loaded; /**< True if the 3D model is currently in VRAM. */
-    int grid_x;           /**< The cell's X coordinate on the grid. */
-    int grid_y;           /**< The cell's Y coordinate on the grid. */
+    int32_t grid_x;       /**< The cell's X coordinate on the grid. */
+    int32_t grid_y;       /**< The cell's Y coordinate on the grid. */
 };
 
 /**
@@ -58,7 +58,7 @@ void grid_destroy(void);
  * @return 0 on success, -EINVAL if room_template is NULL, or -ENOMEM on
  * allocation failure.
  */
-int grid_place_room(int x, int y, const struct room_def* room_template);
+int grid_place_room(int32_t x, int32_t y, const struct room_def* room_template);
 
 /**
  * @brief Retrieves a cell from the grid.
@@ -67,7 +67,7 @@ int grid_place_room(int x, int y, const struct room_def* room_template);
  * @return A pointer to the WorldCell, or NULL if no room exists at that
  * coordinate.
  */
-struct world_cell* grid_get_cell(int x, int y);
+struct world_cell* grid_get_cell(int32_t x, int32_t y);
 
 /**
  * @brief Ensures the 3D model for a room is loaded into memory.

--- a/src/world/generator.c
+++ b/src/world/generator.c
@@ -136,6 +136,11 @@ int generator_create_chunk(int32_t center_x, int32_t center_y) {
             continue;
         }
 
+        if (cell_pos->x == INT32_MAX || cell_pos->x == INT32_MIN ||
+            cell_pos->y == INT32_MAX || cell_pos->y == INT32_MIN) {
+            forbidden_doors = ~required_doors;
+        }
+
         const struct room_def* compatible =
             room_def_find_constrained(required_doors, forbidden_doors);
         if (compatible) {

--- a/src/world/generator.c
+++ b/src/world/generator.c
@@ -13,8 +13,8 @@
 #include "game/world/room_def.h"
 
 struct frontier_cell {
-    int x;
-    int y;
+    int32_t x;
+    int32_t y;
 };
 
 int generator_init(unsigned int seed) {
@@ -47,7 +47,7 @@ int generator_init(unsigned int seed) {
     return 0;
 }
 
-int generator_create_chunk(int center_x, int center_y) {
+int generator_create_chunk(int32_t center_x, int32_t center_y) {
     struct vector frontiers;
 
     if (vector_init(&frontiers) != 0) {
@@ -58,8 +58,8 @@ int generator_create_chunk(int center_x, int center_y) {
 
     int ret = 0;
 
-    for (int y = center_y - 2; y <= center_y + 2; ++y) {
-        for (int x = center_x - 2; x <= center_x + 2; ++x) {
+    for (int32_t y = center_y - 2; y <= center_y + 2; ++y) {
+        for (int32_t x = center_x - 2; x <= center_x + 2; ++x) {
             if (grid_get_cell(x, y) != nullptr) {
                 continue;
             }

--- a/src/world/grid.c
+++ b/src/world/grid.c
@@ -11,7 +11,7 @@
 static struct hashmap grid;
 static bool is_initialized = false;
 
-static inline uint64_t grid_key(int x, int y);
+static inline uint64_t grid_key(int32_t x, int32_t y);
 
 int grid_init() {
     if (is_initialized) {
@@ -47,7 +47,9 @@ void grid_destroy(void) {
     is_initialized = false;
 }
 
-int grid_place_room(int x, int y, const struct room_def* room_template) {
+int grid_place_room(int32_t x,
+                    int32_t y,
+                    const struct room_def* room_template) {
     if (!is_initialized) {
         TraceLog(LOG_WARNING, "GRID: Called place_room before initialization.");
         return -ECANCELED;
@@ -82,7 +84,7 @@ int grid_place_room(int x, int y, const struct room_def* room_template) {
     return 0;
 }
 
-struct world_cell* grid_get_cell(int x, int y) {
+struct world_cell* grid_get_cell(int32_t x, int32_t y) {
     if (!is_initialized) {
         return nullptr;
     }
@@ -121,6 +123,6 @@ int grid_unload_model(struct world_cell* cell) {
     return 0;
 }
 
-static inline uint64_t grid_key(int x, int y) {
-    return ((uint64_t)(x) << 32U) | (uint32_t)(y);
+static inline uint64_t grid_key(int32_t x, int32_t y) {
+    return ((uint64_t)(uint32_t)x << 32U) | (uint32_t)y;
 }

--- a/src/world/world.c
+++ b/src/world/world.c
@@ -13,8 +13,8 @@
 static const float ROOM_SIZE = 4.0F;
 static const int LOAD_RADIUS = 1;
 
-static int player_grid_x = -9999;
-static int player_grid_y = -9999;
+static int32_t player_grid_x = -9999;
+static int32_t player_grid_y = -9999;
 static bool is_initialized = false;
 
 int world_init(unsigned int seed, const char* assets_path) {
@@ -53,8 +53,8 @@ int world_update(Vector3 player_pos) {
         return -EINVAL;
     }
 
-    int new_grid_x = (int)roundf(player_pos.x / ROOM_SIZE);
-    int new_grid_y = (int)roundf(player_pos.z / ROOM_SIZE);
+    int32_t new_grid_x = (int32_t)roundf(player_pos.x / ROOM_SIZE);
+    int32_t new_grid_y = (int32_t)roundf(player_pos.z / ROOM_SIZE);
 
     if (new_grid_x == player_grid_x && new_grid_y == player_grid_y) {
         return 0;
@@ -66,17 +66,17 @@ int world_update(Vector3 player_pos) {
     generator_create_chunk(player_grid_x, player_grid_y);
 
     const int scan_radius = LOAD_RADIUS + 2;
-    for (int y = player_grid_y - scan_radius; y <= player_grid_y + scan_radius;
-         y++) {
-        for (int x = player_grid_x - scan_radius;
+    for (int32_t y = player_grid_y - scan_radius;
+         y <= player_grid_y + scan_radius; y++) {
+        for (int32_t x = player_grid_x - scan_radius;
              x <= player_grid_x + scan_radius; x++) {
             struct world_cell* cell = grid_get_cell(x, y);
             if (!cell) {
                 continue;
             }
 
-            int dist_x = abs(x - player_grid_x);
-            int dist_y = abs(y - player_grid_y);
+            int32_t dist_x = abs(x - player_grid_x);
+            int32_t dist_y = abs(y - player_grid_y);
 
             if (dist_x <= LOAD_RADIUS && dist_y <= LOAD_RADIUS) {
                 grid_load_model(cell);
@@ -94,9 +94,9 @@ int world_draw(void) {
         return -EINVAL;
     }
 
-    for (int y = player_grid_y - LOAD_RADIUS; y <= player_grid_y + LOAD_RADIUS;
-         y++) {
-        for (int x = player_grid_x - LOAD_RADIUS;
+    for (int32_t y = player_grid_y - LOAD_RADIUS;
+         y <= player_grid_y + LOAD_RADIUS; y++) {
+        for (int32_t x = player_grid_x - LOAD_RADIUS;
              x <= player_grid_x + LOAD_RADIUS; x++) {
             struct world_cell* cell = grid_get_cell(x, y);
 

--- a/tests/world/test_generator.c
+++ b/tests/world/test_generator.c
@@ -66,8 +66,8 @@ void test_init_places_start_room_and_chunk(void) {
     assert(strstr(center->template->model_path, "starting_room.glb"));
 
     int room_count = 0;
-    for (int y = -2; y <= 2; y++) {
-        for (int x = -2; x <= 2; x++) {
+    for (int32_t y = -2; y <= 2; y++) {
+        for (int32_t x = -2; x <= 2; x++) {
             if (grid_get_cell(x, y) != nullptr) {
                 room_count++;
             }


### PR DESCRIPTION
This PR changes all handling of coordinate types from `int` to `int32_t` and implements a new logic to handle room placements near the `edge` of the map.